### PR TITLE
Convert float (CVSS) to string before printing

### DIFF
--- a/search.py
+++ b/search.py
@@ -205,7 +205,7 @@ if vSearch:
         else:
             print("CVE\t: " + item['id'])
             print("DATE\t: " + item['Published'])
-            print("CVSS\t: " + item['cvss'])
+            print("CVSS\t: " + str(item['cvss']))
             print(item['summary'])
             print("\nReferences:")
             print("-----------")


### PR DESCRIPTION
This small change fixes the issue on line 208:
"Type Error: Can't convert "float" object to str implicitly" (reported on Kali 1.0.9a / Python 3.2.3)