### PR TITLE
Bugfix

### DIFF
--- a/lib/Config.py
+++ b/lib/Config.py
@@ -257,14 +257,19 @@ class Configuration():
                 multiplier = (split[1]).strip().lower()
                 if multiplier == "b":
                     multiplier = 1
-                elif multiplier == "mb":
+                elif multiplier == "kb":
                     multiplier = 1024
-                elif multiplier == "gb":
+                elif multiplier == "mb":
                     multiplier = 1024 * 1024
+                elif multiplier == "gb":
+                    multiplier = 1024 * 1024 * 1024
+                else:
+                    # If we cannot interpret the multiplier, we take MB as default
+                    multiplier = 1024 * 1024
+            return base * multiplier
         except Exception as e:
             print(e)
-            return 100 * 1024
-        return base * multiplier
+            return 100 * 1024        
 
     @classmethod
     def getBacklog(cls):


### PR DESCRIPTION
We missed "kb" as a multiplier, making "mb" the new kb ;)
Fixed this, and while I was at it, made "mb" the default multiplier, fixing a potential issue when the multiplier could not be interpreted 