### PR TITLE
update of filtering and pagination functionality of cve-search web interface

### DIFF
--- a/bin/search.py
+++ b/bin/search.py
@@ -357,7 +357,7 @@ def search_in_summary(item):
       #  printCVE_json(item)
 
 if cveSearch:
-    for item in db.getCVEs(cves=cveSearch):
+    for item in db.getCVEs(cves=cveSearch)['cves']:
         print_job(item)
     if htmlOutput:
         print("</body></html>")

--- a/lib/CVEs.py
+++ b/lib/CVEs.py
@@ -123,7 +123,7 @@ class last():
 
     def get(self, limit=5, skip=0):
         entries = []
-        for item in db.getCVEs(limit=limit, skip=skip, collection=self.collection):
+        for item in db.getCVEs(limit=limit, skip=skip, collection=self.collection)['cves']:
             if not(self.namelookup) and not(self.rankinglookup):
                 entries.append(item)
             elif self.namelookup or self.rankinglookup:

--- a/lib/CVEs.py
+++ b/lib/CVEs.py
@@ -123,7 +123,7 @@ class last():
 
     def get(self, limit=5, skip=0):
         entries = []
-        for item in db.getCVEs(limit=limit, skip=skip, collection=self.collection)['cves']:
+        for item in db.getCVEs(limit=limit, skip=skip, collection=self.collection)['results']:
             if not(self.namelookup) and not(self.rankinglookup):
                 entries.append(item)
             elif self.namelookup or self.rankinglookup:

--- a/lib/DatabaseLayer.py
+++ b/lib/DatabaseLayer.py
@@ -9,8 +9,8 @@
 
 # imports
 import ast
-import sqlite3
 import pymongo
+#from pymongo import UpdateOne
 import re
 import uuid
 
@@ -44,15 +44,18 @@ def sanitize(x):
     x=list(x)
   if type(x)==list:
     for y in x: sanitize(y)
-  if x and  "_id" in x: x.pop("_id")
+  if x and "_id" in x: x.pop("_id")
   return x
 
 # DB Functions
-def ensureIndex(col, field):
-  db[col].ensure_index(field)
+def ensureIndex(collection, field):
+  db[collection].ensure_index(field)
+  #jdt_NOTE: ensure_index() is deprecated since, create_index() should be used instead
+  #jdt_NOTE: test possible effects of changes on sbin/db_mgmt_create_index.py
+  #db[collection].create_index(field)
 
-def drop(col):
-  db[col].drop()
+def drop(collection):
+  db[collection].drop()
 
 def setColUpdate(collection, date):
   colINFO.update({"db": collection}, {"$set": {"last-modified": date}}, upsert=True)
@@ -74,15 +77,25 @@ def bulkUpdate(collection, data):
     for x in data:
       bulk.find({'id': x['id']}).upsert().update({'$set': x})
     bulk.execute()
+    #jdt_NOTE: initialize_ordered_bulk_op(), initialize_unordered_bulk_op(), BulkOperationBuilder are deprecated, bulk_write() should be used instead
+    #jdt_NOTE: test possible effects of changes on sbin/db_mgmt_ref.py, sbin/db_mgmt_capec.py, sbin/db_mgmt_cwe.py, sbin/db_mgmt_cpe_dictionary.py
+    #requests = []
+    #for x in data:
+    #    requests.append(UpdateOne({'id': x['id']}, {'$set': x}, upsert=True))
+    #result = db[collection].bulk_write(requests)
 
 def cpeotherBulkInsert(cpeotherlist):
   colCPEOTHER.insert(cpeotherlist)
 
 def dropCollection(col):
   return db[col].drop()
+  #jdt_NOTE: is exactly the same as drop(collection)
+  #jdt_NOTE: use only one of them
 
 def getTableNames():
   return db.collection_names()
+  #jdt_NOTE: collection_names() is depreated, list_collection_names() should be used instead
+  #return db.list_collection_names()
 
 # returns True if 'target_version' is less or equal than
 # 'cpe_version'
@@ -127,7 +140,6 @@ def cvesForCPE(cpe, lax=False, vulnProdSearch=False):
         sys.exit(-1)
 
     # over-approximate versions
-    final_cves = []
     cpe_regex = product 
     cves = colCVE.find({cpe_searchField: {"$regex": cpe_regex}}).sort("Modified", -1)
     i = 0
@@ -162,7 +174,8 @@ def cvesForCPE(cpe, lax=False, vulnProdSearch=False):
     cves = colCVE.find({cpe_searchField: {"$regex": cpe_regex}}).sort("Modified", -1)
     final_cves = cves
 
-  return sanitize(final_cves)
+  final_cves = sanitize(final_cves)
+  return {'results': final_cves, 'total': len(final_cves)}
 
 # User Functions
 def addUser(user, pwd, admin=False, localOnly=False):
@@ -203,6 +216,8 @@ def userExists(user):
 
 def isSingleMaster(user):
   return True if len(list(colUSERS.find({"username": {"$ne": user}, "master": True}))) == 0 else False
+  #jdt_NOTE: consider using built in count() of the mongo cursor as in previous functions
+  #return True if colUSERS.find({'username': {'$ne': user}, 'master': True}).count() == 0 else False
 
 # Query Functions
 # Generic data
@@ -216,10 +231,10 @@ def getCVEs(limit=False, query=[], skip=0, cves=None, collection=None):
     cve=col.find(query[0]).sort("Modified", -1).limit(limit).skip(skip)
   else:
     cve=col.find({"$and": query}).sort("Modified", -1).limit(limit).skip(skip)
-  return {'cves': sanitize(cve), 'total': cve.count()}
+  return {'results': sanitize(cve), 'total': cve.count()}
 
 def getCVEsNewerThan(dt):
-  return getCVEs(query={'last-modified': {'$gt': dt}})['cves']
+  return getCVEs(query={'last-modified': {'$gt': dt}})
 
 def getCVEIDs(limit=-1):
   return [x["id"] for x in colCVE.find().limit(limit).sort("Modified", -1)]
@@ -298,7 +313,7 @@ def getSize(collection):
 
 def via4Linked(key, val):
   cveList=[x['id'] for x in colVIA4.find({key: val})]
-  return getCVEs(query={'id':{'$in':cveList}})['cves']
+  return sanitize(getCVEs(query={'id':{'$in':cveList}}))
 
 def getDBStats(include_admin=False):
   data={'cves': {}, 'cpe': {}, 'cpeOther': {}, 'capec': {}, 'cwe': {}, 'via4': {}}

--- a/lib/DatabaseLayer.py
+++ b/lib/DatabaseLayer.py
@@ -216,10 +216,10 @@ def getCVEs(limit=False, query=[], skip=0, cves=None, collection=None):
     cve=col.find(query[0]).sort("Modified", -1).limit(limit).skip(skip)
   else:
     cve=col.find({"$and": query}).sort("Modified", -1).limit(limit).skip(skip)
-  return sanitize(cve)
+  return {'cves': sanitize(cve), 'total': cve.count()}
 
 def getCVEsNewerThan(dt):
-  return sanitize(getCVEs(query={'last-modified': {'$gt': dt}}))
+  return getCVEs(query={'last-modified': {'$gt': dt}})['cves']
 
 def getCVEIDs(limit=-1):
   return [x["id"] for x in colCVE.find().limit(limit).sort("Modified", -1)]
@@ -298,7 +298,7 @@ def getSize(collection):
 
 def via4Linked(key, val):
   cveList=[x['id'] for x in colVIA4.find({key: val})]
-  return sanitize(getCVEs(query={'id':{'$in':cveList}}))
+  return getCVEs(query={'id':{'$in':cveList}})['cves']
 
 def getDBStats(include_admin=False):
   data={'cves': {}, 'cpe': {}, 'cpeOther': {}, 'capec': {}, 'cwe': {}, 'via4': {}}

--- a/lib/Query.py
+++ b/lib/Query.py
@@ -56,7 +56,7 @@ def lookupcpe(cpeid=None):
 
 def lastentries(limit=5, namelookup=False, rankinglookup=True):
   entries = []
-  for item in db.getCVEs(limit)['cves']:
+  for item in db.getCVEs(limit)['results']:
     if not namelookup and rankinglookup is not True:
       entries.append(item)
     else:

--- a/lib/Query.py
+++ b/lib/Query.py
@@ -56,7 +56,7 @@ def lookupcpe(cpeid=None):
 
 def lastentries(limit=5, namelookup=False, rankinglookup=True):
   entries = []
-  for item in db.getCVEs(limit):
+  for item in db.getCVEs(limit)['cves']:
     if not namelookup and rankinglookup is not True:
       entries.append(item)
     else:

--- a/sbin/db_mgmt_cpe_other_dictionary.py
+++ b/sbin/db_mgmt_cpe_other_dictionary.py
@@ -53,9 +53,9 @@ if icve is not None and icpeo is not None:
 # only get collection of new CVE's
 collections = []
 if date:
-    collections = db.getCVEsNewerThan(icve)
+    collections = db.getCVEsNewerThan(icve)['results']
 else:
-    collections = db.getCVEs()['cves']
+    collections = db.getCVEs()['results']
 # check cpes for cves and parse and store missing cpes in cpeother
 batch = []
 

--- a/sbin/db_mgmt_cpe_other_dictionary.py
+++ b/sbin/db_mgmt_cpe_other_dictionary.py
@@ -55,7 +55,7 @@ collections = []
 if date:
     collections = db.getCVEsNewerThan(icve)
 else:
-    collections = db.getCVEs()
+    collections = db.getCVEs()['cves']
 # check cpes for cves and parse and store missing cpes in cpeother
 batch = []
 

--- a/web/api.py
+++ b/web/api.py
@@ -174,7 +174,7 @@ class API():
   def filter_logic(self, filters, skip, limit=None):
     query = self.generate_minimal_query(filters)
     limit = limit if limit else self.args['pageLength']
-    return db.getCVEs(limit=limit, skip=skip, query=query)
+    return db.getCVEs(limit=limit, skip=skip, query=query)['cves']
 
   ##########
   # ROUTES #

--- a/web/api.py
+++ b/web/api.py
@@ -174,7 +174,7 @@ class API():
   def filter_logic(self, filters, skip, limit=None):
     query = self.generate_minimal_query(filters)
     limit = limit if limit else self.args['pageLength']
-    return db.getCVEs(limit=limit, skip=skip, query=query)['cves']
+    return db.getCVEs(limit=limit, skip=skip, query=query)
 
   ##########
   # ROUTES #

--- a/web/index.py
+++ b/web/index.py
@@ -145,10 +145,10 @@ class Index(Minimal, Advanced_API):
     cve   = db.getCVEs(limit=limit, skip=skip, query=query)
     # marking relevant records
     if current_user.is_authenticated():
-        if filters['whitelistSelect'] == "on":   cve = self.list_mark('white', cve)
-        if filters['blacklistSelect'] == "mark": cve = self.list_mark('black', cve)
-    self.plugManager.mark(cve, **self.pluginArgs)
-    cve = list(cve)
+        if filters['whitelistSelect'] == "on":   cve['cves'] = self.list_mark('white', cve['cves'])
+        if filters['blacklistSelect'] == "mark": cve['cves'] = self.list_mark('black', cve['cves'])
+    self.plugManager.mark(cve['cves'], **self.pluginArgs)
+   # cve = list(cve)
     return cve
 
 
@@ -469,7 +469,7 @@ class Index(Minimal, Advanced_API):
           if self.addCPEToList("cpe:/h:" + item[0], listType): added = True
       elif 4 > len(item) > 1:
         # cpe type can be found with a mongo regex query
-        result = db.getCVEs(query={'cpe_2_2': {'$regex': item[1]}})
+        result = db.getCVEs(query={'cpe_2_2': {'$regex': item[1]}})['cve']
         if result.count() != 0:
           prefix = ((result[0])['cpe_2_2'])[:7]
           if len(item) == 2:

--- a/web/index.py
+++ b/web/index.py
@@ -148,7 +148,6 @@ class Index(Minimal, Advanced_API):
         if filters['whitelistSelect'] == "on":   cve['cves'] = self.list_mark('white', cve['cves'])
         if filters['blacklistSelect'] == "mark": cve['cves'] = self.list_mark('black', cve['cves'])
     self.plugManager.mark(cve['cves'], **self.pluginArgs)
-   # cve = list(cve)
     return cve
 
 

--- a/web/index.py
+++ b/web/index.py
@@ -145,9 +145,9 @@ class Index(Minimal, Advanced_API):
     cve   = db.getCVEs(limit=limit, skip=skip, query=query)
     # marking relevant records
     if current_user.is_authenticated():
-        if filters['whitelistSelect'] == "on":   cve['cves'] = self.list_mark('white', cve['cves'])
-        if filters['blacklistSelect'] == "mark": cve['cves'] = self.list_mark('black', cve['cves'])
-    self.plugManager.mark(cve['cves'], **self.pluginArgs)
+        if filters['whitelistSelect'] == "on":   cve['results'] = self.list_mark('white', cve['results'])
+        if filters['blacklistSelect'] == "mark": cve['results'] = self.list_mark('black', cve['results'])
+    self.plugManager.mark(cve, **self.pluginArgs)
     return cve
 
 
@@ -468,7 +468,7 @@ class Index(Minimal, Advanced_API):
           if self.addCPEToList("cpe:/h:" + item[0], listType): added = True
       elif 4 > len(item) > 1:
         # cpe type can be found with a mongo regex query
-        result = db.getCVEs(query={'cpe_2_2': {'$regex': item[1]}})['cve']
+        result = db.getCVEs(query={'cpe_2_2': {'$regex': item[1]}})['results']
         if result.count() != 0:
           prefix = ((result[0])['cpe_2_2'])[:7]
           if len(item) == 2:

--- a/web/minimal.py
+++ b/web/minimal.py
@@ -84,7 +84,6 @@ class Minimal(API):
       errors = True
     return {'filters': filters, 'cve': cve, 'errors': errors}
 
-
   ##########
   # ROUTES #
   ##########
@@ -157,7 +156,7 @@ class Minimal(API):
     if search == '':
        return self.index()
     result = db.getSearchResults(search)
-    cve=result['data']
+    cve={'results': result['data'], 'total': len(result['data'])}
     errors=result['errors'] if 'errors' in result else []
     return render_template('search.html', cve=cve, errors=errors, freetextsearch=search, minimal=self.minimal)
 

--- a/web/minimal.py
+++ b/web/minimal.py
@@ -75,7 +75,6 @@ class Minimal(API):
 
   def getFilterSettingsFromPost(self, r):
     filters = dict(request.form)
-    filters = {x: filters[x][0] for x in filters.keys()}
     errors  = False
     # retrieving data
     try:
@@ -84,7 +83,6 @@ class Minimal(API):
       cve = db.getCVEs(limit=self.args['pageLength'], skip=r)
       errors = True
     return {'filters': filters, 'cve': cve, 'errors': errors}
-    return(filters,cve,errors)
 
 
   ##########

--- a/web/static/js/custom/pager.js
+++ b/web/static/js/custom/pager.js
@@ -1,5 +1,5 @@
-function paginator_jump(n) {
+function paginator_jump(offset) {
 	var form = document.getElementById('filter');
-	form.action = '/r/' + n;
-	form.submit()
+	form.action = '/r/' + offset
+	form.submit();
 }

--- a/web/static/js/custom/pager.js
+++ b/web/static/js/custom/pager.js
@@ -1,18 +1,5 @@
-// Requires filter.js, where setSetings() is located
-function postURL(url) {
-  var form = document.getElementById("filter");
-  form.action = url;
-  form.submit();
-}
-function next(n){
-  setSettings();
-  var url = "/r/"+n;
-  postURL(url);
-}
-function previous(n){
-  setSettings();
-  if(n < 0){
-    n = 0;}
-  var url = "/r/" + n;
-  postURL(url);
+function paginator_jump(n) {
+	var form = document.getElementById('filter');
+	form.action = '/r/' + n;
+	form.submit()
 }

--- a/web/templates/index-minimal.html
+++ b/web/templates/index-minimal.html
@@ -8,15 +8,21 @@
   <script type="text/javascript" src="/static/js/custom/filter.js"></script>
   <script type="text/javascript" src="/static/js/custom/pager.js"></script>
   <script type="text/javascript">
-    function setSettings(){
-      {% if settings is defined%}
-        document.getElementById('timeSelect').value = "{{settings['timeSelect']}}";
-        document.getElementById('startDate').value = "{{settings['startDate']}}";
-        document.getElementById('endDate').value = "{{settings['endDate']}}";
-        document.getElementById('timeTypeSelect').value = "{{settings['timeTypeSelect']}}";
-        document.getElementById('cvssSelect').value = "{{settings['cvssSelect']}}";
-        document.getElementById('cvss').value = "{{settings['cvss']}}";
-        document.getElementById('rejectedSelect').value = "{{settings['rejectedSelect']}}";
+    $(document).ready(function(){
+      setFilters();
+      {% if errors %}
+        setStatus("An error occured while parsing the filters. Please verify the input fields, like the dates", "danger");
+      {% endif %}
+    })
+    function setFilters(){
+      {% if filters is defined %}
+        {% for key, val in filters.items() %}
+          if($("#{{key}}").is(":checkbox")){
+            if("{{val}}" === "on"){$("#{{key}}").prop('checked', true);}
+          }else{
+            $("#{{key}}").val("{{val}}");
+          }
+        {% endfor %}
         cvssSelectDisable()
         timeSelectDisable()
       {%endif%}

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -9,14 +9,14 @@
   <script type="text/javascript" src="/static/js/custom/pager.js"></script>
   <script type="text/javascript">
     $(document).ready(function(){
-      setSettings();
+      setFilters();
       {% if errors %}
         setStatus("An error occured while parsing the filters. Please verify the input fields, like the dates", "danger");
       {% endif %}
     })
-    function setSettings(){
-      {% if settings is defined %}
-        {% for key, val in settings.items() %}
+    function setFilters(){
+      {% if filters is defined %}
+        {% for key, val in filters.items() %}
           if($("#{{key}}").is(":checkbox")){
             if("{{val}}" === "on"){$("#{{key}}").prop('checked', true);}
           }else{
@@ -27,7 +27,6 @@
         timeSelectDisable()
       {%endif%}
     }
-
   </script>
 {% endblock %}
 {% block content %}

--- a/web/templates/search.html
+++ b/web/templates/search.html
@@ -28,7 +28,7 @@
   {% endif %}
 
   {% include 'subpages/table.html' %}
-  {% if not vendor and cve|length == 100 %}
+  {% if not vendor and cve['results']|length == 100 %}
     <p>Top 100 results</p>
   {% endif %}
 {% endblock %}

--- a/web/templates/subpages/filters.html
+++ b/web/templates/subpages/filters.html
@@ -3,7 +3,7 @@
 </button>
   
 <div id="filterdiv" class="collapse well well-small">  
-  <form method="POST" id="filter" class="nav form-search">
+  <form method="POST" action="/r/0" id="filter" class="nav form-search">
     <table class="searchTable">
       {% if (current_user is defined and current_user.is_authenticated())or listLogin == False %}
         <tr>

--- a/web/templates/subpages/pager.html
+++ b/web/templates/subpages/pager.html
@@ -1,42 +1,77 @@
-<!-- 
-You can change the length to however long you want.
-For the best result, use an odd number
- -->
-{% set length = 5%}
+{% set adjacent = 3 %}
+{% set pageTotal = cve['total'] %}
+{% set pageCurrent = (r / pageLength)|int + 1 %}
 
-<!-- Don't edit the variables below -->
-{% set page = (r/pageLength)|int %}
-{% set middle = (length/2)|int+1 %}
-{% if page < middle %}
-  {% set pre = page %}
-  {% set post = length-page%}
-{% else %}
-  {% set pre = middle-1 %}
-  {% set post = middle%}
+{% set prev = pageCurrent - 1 %}
+{% set next = pageCurrent + 1 %}
+{% set pageLast = (pageTotal / pageLength)|int %}
+{% if(pageTotal % pageLength > 0) %}
+  {% set pageLast = pageLast + 1%}
 {% endif %}
-
+{% set lpm1 = pageLast - 1 %}
 <div class="pagerdiv">
   <nav>
     <ul class="pagination">
-      <li {% if r == 0 %}class="disabled"{% endif %}>
-        <a href="javascript:previous(1)" aria-label="Previous">
-          <span aria-hidden="true">&laquo;</span>
-        </a>
-      </li>
-      {% for n in range(pre,0,-1) %}
-        <li><a href="javascript:previous({{r - n * pageLength}})">{{page - n+1}}</a></li>
+
+{% if(pageLast >= 1) %}
+  {% if(pageCurrent > 1) %}
+    <li><a href="javascript:paginator_jump({{r - pageLength}})">&laquo;</a></li>
+  {% else %}
+    <li class="disabled"><a>&laquo;</a></li>
+  {% endif %}
+  {% if(pageLast < 7 + (adjacent * 2)) %}
+    {% for n in range(1, pageLast + 1) %}
+      {% if(n == pageCurrent) %}
+        <li class="active"><a href="">{{n}}</a></li>
+      {% else %}
+        <li><a href="javascript:paginator_jump({{(n - 1) * pageLength}})">{{n}}</a></li>
+      {% endif %}
+    {% endfor %}
+  {% elif(pageLast > 5 + (adjacent * 2)) %}
+    {% if(pageCurrent < 1 + (adjacent * 2)) %}
+      {% for n in range(1, 4 + (adjacent * 2)) %}
+        {% if(n == pageCurrent) %}
+          <li class="active"><a href="">{{n}}</a></li>
+        {% else %}
+  	  <li><a href="javascript:paginator_jump({{(n - 1) * pageLength}})">{{n}}</a></li>
+        {% endif %}
       {% endfor %}
-      <li class="active">
-        <span>{{page+1}} <span class="sr-only">(current)</span></span>
-      </li>
-      {% for n in range(1,post) %}
-        <li><a href="javascript:next({{r + n * pageLength}})">{{page + n+1}}</a></li>
+      <li class="disabled"><a>..</a></li>
+      <li><a href="javascript:paginator_jump({{(lpm1 - 1) * pageLength}})">{{lpm1}}</a></li>
+      <li><a href="javascript:paginator_jump({{(pageLast - 1) * pageLength}})">{{pageLast}}</a></li>
+    {% elif(pageLast - (adjacent * 2) > pageCurrent and pageCurrent > (adjacent * 2)) %}
+      <li><a href="javascript:paginator_jump({{0}})">1</a></li>
+      <li><a href="javascript:paginator_jump({{pageLength}})">2</a></li>
+      <li class="disabled"><a>..</a></li>
+      {% for n in range(pageCurrent - adjacent, pageCurrent + adjacent + 1) %}
+        {% if(n == pageCurrent) %}
+          <li class="active"><a href="">{{n}}</a></li>
+        {% else %}
+	  <li><a href="javascript:paginator_jump({{(n - 1) * pageLength}})">{{n}}</a></li>
+        {% endif %}
       {% endfor %}
-      <li>
-        <a href="javascript:next(1)" aria-label="Next">
-          <span aria-hidden="true">&raquo;</span>
-        </a>
-      </li>
+      <li class="disabled"><a>..</a></li>
+      <li><a href="javascript:paginator_jump({{(lpm1 - 1) * pageLength}})">{{lpm1}}</a></li>
+      <li><a href="javascript:paginator_jump({{(pageLast - 1) * pageLength}})">{{pageLast}}</a></li>
+    {% else %}
+      <li><a href="javascript:paginator_jump({{0}})">1</a></li>
+      <li><a href="javascript:paginator_jump({{pageLength}})">2</a></li>
+      <li class="disabled"><a>..</a></li>
+      {% for n in range(pageLast - (2 + (adjacent * 2)), pageLast + 1) %}
+        {% if(n == pageCurrent) %}
+          <li class="active"><a href="">{{n}}</a></li>
+        {% else %}
+	  <li><a href="javascript:paginator_jump({{(n - 1) * pageLength}})">{{n}}</a></li>
+        {% endif %}
+      {% endfor  %}
+    {% endif %}
+  {% endif %}
+  {% if(pageCurrent < pageLast) %}
+    <li><a href="javascript:paginator_jump({{r + pageLength}})">&raquo;</a></li>
+  {% else %}
+    <li class="disabled"><a>&raquo;</a></li>
+  {% endif %}
+{% endif %}
     </ul>
   </nav>
 </div>

--- a/web/templates/subpages/pager.html
+++ b/web/templates/subpages/pager.html
@@ -1,18 +1,13 @@
 {% set adjacent = 3 %}
 {% set pageTotal = cve['total'] %}
 {% set pageCurrent = (r / pageLength)|int + 1 %}
-
-{% set prev = pageCurrent - 1 %}
-{% set next = pageCurrent + 1 %}
 {% set pageLast = (pageTotal / pageLength)|int %}
 {% if(pageTotal % pageLength > 0) %}
-  {% set pageLast = pageLast + 1%}
+  {% set pageLast = pageLast + 1 %}
 {% endif %}
-{% set lpm1 = pageLast - 1 %}
 <div class="pagerdiv">
   <nav>
     <ul class="pagination">
-
 {% if(pageLast >= 1) %}
   {% if(pageCurrent > 1) %}
     <li><a href="javascript:paginator_jump({{r - pageLength}})">&laquo;</a></li>
@@ -37,7 +32,7 @@
         {% endif %}
       {% endfor %}
       <li class="disabled"><a>..</a></li>
-      <li><a href="javascript:paginator_jump({{(lpm1 - 1) * pageLength}})">{{lpm1}}</a></li>
+      <li><a href="javascript:paginator_jump({{(pageLast - 2) * pageLength}})">{{pageLast - 1}}</a></li>
       <li><a href="javascript:paginator_jump({{(pageLast - 1) * pageLength}})">{{pageLast}}</a></li>
     {% elif(pageLast - (adjacent * 2) > pageCurrent and pageCurrent > (adjacent * 2)) %}
       <li><a href="javascript:paginator_jump({{0}})">1</a></li>
@@ -51,7 +46,7 @@
         {% endif %}
       {% endfor %}
       <li class="disabled"><a>..</a></li>
-      <li><a href="javascript:paginator_jump({{(lpm1 - 1) * pageLength}})">{{lpm1}}</a></li>
+      <li><a href="javascript:paginator_jump({{(pageLast - 2) * pageLength}})">{{pageLast - 1}}</a></li>
       <li><a href="javascript:paginator_jump({{(pageLast - 1) * pageLength}})">{{pageLast}}</a></li>
     {% else %}
       <li><a href="javascript:paginator_jump({{0}})">1</a></li>

--- a/web/templates/subpages/table.html
+++ b/web/templates/subpages/table.html
@@ -5,7 +5,7 @@
     </tr>
   </thead>
   <tbody>
-    {% for c in cve %}
+    {% for c in cve['cves'] %}
     {% if 'whitelisted' in c %}{%set class="whitelisted"%}{% elif 'blacklisted' in c %}{%set class="blacklisted"%}
     {% else %}{%set class=""%}{% endif %}
       <tr id ="{{ c['id'] }}" class="{{class}}" {{'style=color:'+c['color'] if 'color' in c else ''}}>

--- a/web/templates/subpages/table.html
+++ b/web/templates/subpages/table.html
@@ -5,7 +5,7 @@
     </tr>
   </thead>
   <tbody>
-    {% for c in cve['cves'] %}
+    {% for c in cve['results'] %}
     {% if 'whitelisted' in c %}{%set class="whitelisted"%}{% elif 'blacklisted' in c %}{%set class="blacklisted"%}
     {% else %}{%set class=""%}{% endif %}
       <tr id ="{{ c['id'] }}" class="{{class}}" {{'style=color:'+c['color'] if 'color' in c else ''}}>


### PR DESCRIPTION
- for current version of cve-search, there are problems with filtering and pagination
  - filtering
    - filter values are lost upon page refresh or by movement by pagination elements
  - pagination
    - everytime display 5 paginator elements (even in case there is only one result page)
    - previous and next buttons are not working correctly

- the aformentioned problems have been fixed by
  - changes in the getCVEs function (now returns a dictionary containing both the cve data 'cves' and total number of results 'total' for pagination purposes)
  - complete rework of pagination generator
  - small changes of functions in order to maintain original functionality after changin the return type of getCVEs function